### PR TITLE
Remove leftover debug artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dataset/
 .vscode/
 .nf-test/
 .nf-test.log
+null

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -75,7 +75,6 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename ->
                 if(!filename.equals('versions.yml')) {
-                    System.out.println("filename: ${filename}")
                     if (filename.replace("${meta.id}", "").contains("_1_")){
                         "${meta.id}_1.fastq.gz"
                     } else if (filename.replace("${meta.id}", "").contains("_2_")){


### PR DESCRIPTION
## Summary

- remove the leftover filename debug output from the `BBMAP_REPAIR` publish closure
- add a `null` ignore rule; the stray root file is already absent from current `dev`

## Validation

- `prek run --all-files`
- `nf-core pipelines lint --dir .` (284 passed, 18 pre-existing warnings, 0 failed)
- `nf-test test --dry-run --ci --profile=+docker tests` (2 tests discovered and passed)
- container-free `nextflow run main.nf -profile test -stub-run ...` smoke through MultiQC, with no `filename:` output
- focused publish-closure probe confirming all three output renames and no debug output

A Docker-profile execution was not available locally because Docker, Podman, Singularity, and Apptainer are not installed; CI can run the full container-backed tests.

Closes #37

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) — pending container-backed CI; local dry-run and stub-run validation passed.
