### PR TITLE
Track mate identity through WiperTools processing

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -33,13 +33,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename ->
                 if(!filename.equals('versions.yml')) {
-                    if (filename.replace("${meta.sample_id}", "").contains("_1_")){
-                        "${meta.sample_id}_1.report"
-                    } else if (filename.replace("${meta.sample_id}", "").contains("_2_")){
-                        "${meta.sample_id}_2.report"
-                    } else {
-                        "${meta.sample_id}.report"
-                    }
+                    meta.mate ? "${meta.sample_id}_${meta.mate}.report" : "${meta.sample_id}.report"
                 } else {
                     null
                 }
@@ -53,13 +47,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename ->
                 if(!filename.equals('versions.yml') && (meta.single_end || params.skip_bbmap_repair)) {
-                    if (filename.replace("${meta.sample_id}", "").contains("_1_")){
-                        "${meta.sample_id}_1.fastq.gz"
-                    } else if (filename.replace("${meta.sample_id}", "").contains("_2_")){
-                        "${meta.sample_id}_2.fastq.gz"
-                    } else {
-                        "${meta.sample_id}.fastq.gz"
-                    }
+                    meta.mate ? "${meta.sample_id}_${meta.mate}.fastq.gz" : "${meta.sample_id}.fastq.gz"
                 } else {
                     null
                 }
@@ -76,9 +64,9 @@ process {
             saveAs: { filename ->
                 if(!filename.equals('versions.yml')) {
                     System.out.println("filename: ${filename}")
-                    if (filename.replace("${meta.id}", "").contains("_1_")){
+                    if (filename.equals("${meta.id}_1_repaired.fastq.gz")){
                         "${meta.id}_1.fastq.gz"
-                    } else if (filename.replace("${meta.id}", "").contains("_2_")){
+                    } else if (filename.equals("${meta.id}_2_repaired.fastq.gz")){
                         "${meta.id}_2.fastq.gz"
                     } else {
                         "${meta.id}_singleton.fastq.gz"

--- a/subworkflows/local/fastq_repair_wipertools/main.nf
+++ b/subworkflows/local/fastq_repair_wipertools/main.nf
@@ -14,8 +14,8 @@ workflow FASTQ_REPAIR_WIPERTOOLS {
     // decouple fastq files [sample_id = id; id is the file name]
     ch_decoupled = ch_fastq.flatMap {
         meta, fastqList -> fastqList instanceof List
-        ? fastqList.collect { fastq -> tuple("id": (fastq.name.endsWith(".gz") ? fastq.getBaseName(2): fastq.baseName), "sample_id":meta.id, "single_end": meta.single_end, fastq) }
-        : [tuple("id": (fastqList.name.endsWith(".gz") ? fastqList.getBaseName(2): fastqList.baseName), "sample_id":meta.id, "single_end": meta.single_end, fastqList)]
+        ? fastqList.withIndex().collect { fastq, index -> tuple("id": (fastq.name.endsWith(".gz") ? fastq.getBaseName(2): fastq.baseName), "sample_id":meta.id, "single_end": meta.single_end, "mate": index + 1, fastq) }
+        : [tuple("id": (fastqList.name.endsWith(".gz") ? fastqList.getBaseName(2): fastqList.baseName), "sample_id":meta.id, "single_end": meta.single_end, "mate": null, fastqList)]
     }
 
     // Split fastq files into chunks
@@ -30,11 +30,12 @@ workflow FASTQ_REPAIR_WIPERTOOLS {
     mate_id     = (previous) id, i.e., the original, not split, file name
     sample_id   = the id of the original meta
     single_end  = the single_end status of the original meta
+    mate        = the position of the file in the original paired-end input
     */
     ch_scattered_fastq = WIPERTOOLS_FASTQSCATTER.out.fastq_chunks.flatMap {
         meta, fastqList -> fastqList.collect {
             fastq -> tuple("id": (fastq.name.endsWith(".gz") ? fastq.getBaseName(2) : fastq.baseName),
-            "mate_id":meta.id, "sample_id":meta.sample_id, "single_end": meta.single_end, fastq) } }
+            "mate_id":meta.id, "sample_id":meta.sample_id, "single_end": meta.single_end, "mate": meta.mate, fastq) } }
 
     // Wipe fastq files
     WIPERTOOLS_FASTQWIPER {
@@ -45,9 +46,9 @@ workflow FASTQ_REPAIR_WIPERTOOLS {
     // group wiped chunks
     ch_cleaned_fastq = Channel.empty()
     WIPERTOOLS_FASTQWIPER.out.wiped_fastq
-    | map { meta, fq -> [meta.subMap('mate_id', 'sample_id', 'single_end'), fq]}
+    | map { meta, fq -> [meta.subMap('mate_id', 'sample_id', 'single_end', 'mate'), fq]}
     | groupTuple
-    | map { meta, fq -> [['id':meta.mate_id, 'sample_id':meta.sample_id, 'single_end':meta.single_end], fq]}
+    | map { meta, fq -> [['id':meta.mate_id, 'sample_id':meta.sample_id, 'single_end':meta.single_end, 'mate':meta.mate], fq]}
     | set { ch_cleaned_fastq }
 
     // gather fastq files
@@ -59,9 +60,9 @@ workflow FASTQ_REPAIR_WIPERTOOLS {
     // group wiping reports
     ch_gathered_report = Channel.empty()
     WIPERTOOLS_FASTQWIPER.out.report
-    | map { meta, report -> [meta.subMap('mate_id', 'sample_id', 'single_end'), report]}
+    | map { meta, report -> [meta.subMap('mate_id', 'sample_id', 'single_end', 'mate'), report]}
     | groupTuple
-    | map { meta, report -> [['id':meta.mate_id, 'sample_id':meta.sample_id, 'single_end':meta.single_end], report]}
+    | map { meta, report -> [['id':meta.mate_id, 'sample_id':meta.sample_id, 'single_end':meta.single_end, 'mate':meta.mate], report]}
     | set { ch_gathered_report }
 
     // gather report files and replace meta.id with meta.sample_id

--- a/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_1.fastq
+++ b/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_1.fastq
@@ -1,0 +1,4 @@
+@read_from_second_input
+ACGT
++
+IIII

--- a/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_2.fastq
+++ b/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_2.fastq
@@ -1,0 +1,4 @@
+@read_from_first_input
+TGCA
++
+IIII

--- a/subworkflows/local/fastq_repair_wipertools/tests/mate_metadata.nf.test
+++ b/subworkflows/local/fastq_repair_wipertools/tests/mate_metadata.nf.test
@@ -1,0 +1,43 @@
+nextflow_workflow {
+
+    name "Test mate metadata in FASTQ_REPAIR_WIPERTOOLS"
+    script "../main.nf"
+    workflow "FASTQ_REPAIR_WIPERTOOLS"
+
+    tag "subworkflows"
+    tag "subworkflows/fastq_repair_wipertools"
+    tag "mate_metadata"
+
+    test("mate assignment follows input order, not filenames") {
+        options "-stub"
+
+        when {
+            params {
+                outdir            = "$outputDir/mate_metadata"
+                publish_dir_mode  = "copy"
+                num_splits        = 2
+                skip_bbmap_repair = true
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'misleading_1_name', single_end:false ],
+                    [file("\${projectDir}/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_2.fastq", checkIfExists: true),
+                    file("\${projectDir}/subworkflows/local/fastq_repair_wipertools/tests/fixtures/ambiguous_1.fastq", checkIfExists: true)]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.wiped_fastq.collect { it[0].mate }.sort() == [1, 2] },
+                { assert new File("$outputDir/mate_metadata/repaired/misleading_1_name_1.fastq.gz").exists() },
+                { assert new File("$outputDir/mate_metadata/repaired/misleading_1_name_2.fastq.gz").exists() },
+                { assert new File("$outputDir/mate_metadata/repaired/misleading_1_name_1.report").exists() },
+                { assert new File("$outputDir/mate_metadata/repaired/misleading_1_name_2.report").exists() }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- assign an explicit mate number from paired-end input order during FASTQ decoupling
- preserve mate metadata through scatter, wipe, and gather operations
- use mate metadata for WiperTools publication names and exact BBMap output names instead of filename substring heuristics
- add a self-contained stub regression test with reversed, deliberately ambiguous FASTQ names

## Testing

- `nf-test 0.9.5` with Nextflow `24.04.2`: mate metadata regression test passed in stub mode

Closes #46
